### PR TITLE
set linux tests to sequential execution

### DIFF
--- a/testAll.sh
+++ b/testAll.sh
@@ -13,6 +13,10 @@ if test "$1" = "seq"; then
     sequential=1
 fi
 
+if isOSlinux; then
+    sequential=1
+fi
+
 imunes -i
 
 tests="DHCP DHCP6+RSOL DNS+Mail+WEB OSPF Ping RIP BGP Traceroute services"


### PR DESCRIPTION
in parallel mode most tests tend to break even on 4 cores Xeon E5-2650
with 4GB of RAM on SSD storage, even if they work OK if executed
one by one