### PR TITLE
Fix errors when running "services" test

### DIFF
--- a/services/test.sh
+++ b/services/test.sh
@@ -7,6 +7,9 @@ err=0
 eid=`imunes -b services.imn | awk '/Experiment/{print $4; exit}'`
 startCheck "$eid"
 
+# wait for the services to start
+sleep 5
+
 # ftp
 himage FTP@$eid netstat -an | grep LISTEN | grep -q "21"
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Errors were occurring on every run of the services/test.sh script because the script checked if the services were up and running before they had the time to get up and running. This fix postpones the testing so that the services have the time needed to start.