### PR TITLE
Fix relay access denied error in Postfix mail examples for older Ubuntu/IMUNES versions

### DIFF
--- a/DNS+Mail+WEB/Mail_files/postfix.www/linux-main.cf
+++ b/DNS+Mail+WEB/Mail_files/postfix.www/linux-main.cf
@@ -201,7 +201,7 @@ mydestination = $myhostname, localhost.$mydomain, localhost, $mydomain, /etc/pos
 # 
 #local_recipient_maps = unix:passwd.byname $alias_maps
 #local_recipient_maps = proxy:unix:passwd.byname $alias_maps
-
+local_recipient_maps =
 
 # The unknown_local_recipient_reject_code specifies the SMTP server
 # response code when a recipient domain matches $mydestination or

--- a/DNS+Mail+WEB/Mail_files/postfix.www/linux-main.cf
+++ b/DNS+Mail+WEB/Mail_files/postfix.www/linux-main.cf
@@ -155,7 +155,7 @@ myorigin = www.tel.fer.hr
 #
 #mydestination = $myhostname, localhost.$mydomain, localhost
 
-mydestination = $myhostname, localhost.$mydomain, localhost, $mydomain, /etc/postfix/local-host-names
+mydestination = $myhostname, localhost.$mydomain, localhost, $mydomain, /etc/postfix/local-host-names, tel.fer.hr
 
 #mydestination = $myhostname, localhost.$mydomain, localhost, $mydomain,
 #	mail.$mydomain, www.$mydomain, ftp.$mydomain
@@ -201,7 +201,7 @@ mydestination = $myhostname, localhost.$mydomain, localhost, $mydomain, /etc/pos
 # 
 #local_recipient_maps = unix:passwd.byname $alias_maps
 #local_recipient_maps = proxy:unix:passwd.byname $alias_maps
-#local_recipient_maps =
+
 
 # The unknown_local_recipient_reject_code specifies the SMTP server
 # response code when a recipient domain matches $mydestination or
@@ -258,6 +258,10 @@ unknown_local_recipient_reject_code = 550
 #mynetworks = 168.100.189.0/28, 127.0.0.0/8
 #mynetworks = $config_directory/mynetworks
 #mynetworks = hash:/usr/local/etc/postfix/network_table
+# NOTE: mynetworks = 0.0.0.0/0 is required for IMUNES emulation environment.
+# This allows all nodes in the simulation to relay mail.
+# NEVER use this configuration in production or on internet-facing systems.
+mynetworks = 0.0.0.0/0
 
 # The relay_domains parameter restricts what destinations this system will
 # relay mail to.  See the smtpd_recipient_restrictions description in
@@ -309,6 +313,7 @@ unknown_local_recipient_reject_code = 550
 #relayhost = [mailserver.isp.tld]
 #relayhost = uucphost
 #relayhost = [an.ip.add.ress]
+relayhost =
 
 # REJECTING UNKNOWN RELAY USERS
 #

--- a/DNS+Mail+WEB/Mail_files/postfix.zpmMail/linux-main.cf
+++ b/DNS+Mail+WEB/Mail_files/postfix.zpmMail/linux-main.cf
@@ -155,7 +155,7 @@ myhostname = zpmMail.zpm.fer.hr
 #
 #mydestination = $myhostname, localhost.$mydomain, localhost
 
-mydestination = $myhostname, localhost.$mydomain, localhost, $mydomain, /etc/postfix/local-host-names
+mydestination = $myhostname, localhost.$mydomain, localhost, $mydomain, /etc/postfix/local-host-names, zpm.fer.hr
 
 #mydestination = $myhostname, localhost.$mydomain, localhost, $mydomain,
 #	mail.$mydomain, www.$mydomain, ftp.$mydomain
@@ -201,7 +201,7 @@ mydestination = $myhostname, localhost.$mydomain, localhost, $mydomain, /etc/pos
 # 
 #local_recipient_maps = unix:passwd.byname $alias_maps
 #local_recipient_maps = proxy:unix:passwd.byname $alias_maps
-#local_recipient_maps =
+local_recipient_maps =
 
 # The unknown_local_recipient_reject_code specifies the SMTP server
 # response code when a recipient domain matches $mydestination or
@@ -258,6 +258,10 @@ unknown_local_recipient_reject_code = 550
 #mynetworks = 168.100.189.0/28, 127.0.0.0/8
 #mynetworks = $config_directory/mynetworks
 #mynetworks = hash:/usr/local/etc/postfix/network_table
+# NOTE: mynetworks = 0.0.0.0/0 is required for IMUNES emulation environment.
+# This allows all nodes in the simulation to relay mail.
+# NEVER use this configuration in production or on internet-facing systems.
+mynetworks = 0.0.0.0/0
 
 # The relay_domains parameter restricts what destinations this system will
 # relay mail to.  See the smtpd_recipient_restrictions description in
@@ -309,6 +313,7 @@ unknown_local_recipient_reject_code = 550
 #relayhost = [mailserver.isp.tld]
 #relayhost = uucphost
 #relayhost = [an.ip.add.ress]
+relayhost =
 
 # REJECTING UNKNOWN RELAY USERS
 #


### PR DESCRIPTION
This pull request fixes a "Relay access denied" error that occurs when sending email (e.g., from root@tel.fer.hr) in the IMUNES mail examples on older Ubuntu versions (tested with IMUNES v3.0.0b, git: d4b35ef, 2026-02-27).

Possible root cause: Newer Postfix versions on Ubuntu enforce stricter default relay restrictions, causing the example to fail.
Solution: Updated mynetworks, local_recipient_maps, mydestinations, and relayhost settings in:

DNS+Mail+WEB/Mail_files/postfix.www/linux-main.cf
DNS+Mail+WEB/Mail_files/postfix.zpmMail/linux-main.cf

**Security Note**: 
The mynetworks = 0.0.0.0/0 setting is appropriate for IMUNES' isolated emulation environments where all nodes are trusted. However, this configuration must never be used in production or on internet-facing systems. I've added comments to the config files to make this clear.
This change restores the intended functionality of the examples, allowing them to work out-of-the-box in the IMUNES testing environment.
